### PR TITLE
feat: added decoding of function call to parse_script

### DIFF
--- a/production/avotes-parser-core/avotes_parser/core/parsing.py
+++ b/production/avotes-parser-core/avotes_parser/core/parsing.py
@@ -123,13 +123,13 @@ class EVMScript(PrettyPrinted):
             f'{offset}Script executor ID: {self.spec_id}'
         )
 
-        calls = '\n'.join((
+        calls = '\n'.join(
             call.pretty_print(
                 offset=offset_size + PRETTY_PRINT_NEXT_LEVEL_OFFSET,
                 **kwargs
             ) if isinstance(call, PrettyPrinted) else repr(call)
             for call in self.calls
-        ))
+        )
         calls = (
             f'{offset}Calls:\n'
             f'{calls}'

--- a/production/avotes-parser-core/avotes_parser/core/parsing.py
+++ b/production/avotes-parser-core/avotes_parser/core/parsing.py
@@ -3,8 +3,10 @@ Parsing payload of aragon votes.
 """
 import json
 from dataclasses import dataclass, field, asdict
-from typing import Tuple, List
+from typing import Optional, Tuple, List, Union
 
+from .ABI.storage import ABI, ABIKey, CachedStorage
+from .decoding import Call, decode_function_call
 from .pretty_printed import PrettyPrinted
 from .spec import (
     LENGTH_SPEC_ID, LENGTH_ADDRESS,
@@ -111,7 +113,7 @@ class EVMScript(PrettyPrinted):
     # Script executor id
     spec_id: str = field(default=DEFAULT_SPEC_ID)
     # Calls data
-    calls: List[EncodedCall] = field(default_factory=list)
+    calls: Union[List[EncodedCall], List[Call]] = field(default_factory=list)
 
     def pretty_print(self, *_, **kwargs) -> str:
         """Get human-readable form."""
@@ -184,11 +186,18 @@ def _parse_single_call(
     )
 
 
-def parse_script(encoded_script: str) -> EVMScript:
+CacheT = CachedStorage[Union[ABIKey, Tuple[ABIKey, ABIKey]], ABI]
+
+
+def parse_script(
+    encoded_script: str,
+    abi_storage: Optional[CacheT] = None,
+) -> EVMScript:
     """
     Parse encoded EVM script.
 
     :param encoded_script: str, encoded EVM script.
+    :param abi_storage: CachedStorage, storage of contracts ABI.
     :return: parsed script as instance of EVMScript object.
     """
     if encoded_script.startswith(HEX_PREFIX):
@@ -200,6 +209,16 @@ def parse_script(encoded_script: str) -> EVMScript:
     while i < len(encoded_script):
         i, one_call = _parse_single_call(encoded_script, i)
         calls_data.append(one_call)
+
+    if abi_storage is not None:
+        calls_data = [
+            decode_function_call(
+                contract_address=call.address,
+                function_signature=call.method_id,
+                call_data=call.encoded_call_data,
+                abi_storage=abi_storage,
+            ) for call in calls_data
+        ]
 
     return EVMScript(
         spec_id, calls_data

--- a/production/avotes-parser-core/tests/test_encoding_parsing.py
+++ b/production/avotes-parser-core/tests/test_encoding_parsing.py
@@ -20,8 +20,7 @@ parse_with_decoding_examples = (
             spec_id='00000001',
             calls=[
                 Call(
-                    contract_address="0x9d4af1ee19dad8857db"
-                                     "3a45b0374c81c8a1c6320",
+                    contract_address="0x9d4af1ee19dad8857db3a45b0374c81c8a1c6320", # noqa
                     function_signature="0xae962acf",
                     function_name="setNodeOperatorStakingLimit",
                     inputs=[

--- a/production/avotes-parser-core/tests/test_encoding_parsing.py
+++ b/production/avotes-parser-core/tests/test_encoding_parsing.py
@@ -1,0 +1,81 @@
+from collections import namedtuple
+
+import pytest
+
+from avotes_parser.core import parse_script, EVMScript
+from avotes_parser.core.ABI.provider import get_cached_etherscan_api
+from avotes_parser.core.decoding import FuncInput, Call
+
+ParsingTestCase = namedtuple(
+    'ParsingTestCase', field_names=['raw_script', 'parsed_script']
+)
+
+parse_with_decoding_examples = (
+    ParsingTestCase(
+        raw_script="0x000000019d4af1ee19dad8857db3a45b0374c81c8a1c632000000044"
+                   "ae962acf00000000000000000000000000000000000000000000000000"
+                   "0000000000000c00000000000000000000000000000000000000000000"
+                   "0000000000000000001d",
+        parsed_script=EVMScript(
+            spec_id='00000001',
+            calls=[
+                Call(
+                    contract_address="0x9d4af1ee19dad8857db"
+                                     "3a45b0374c81c8a1c6320",
+                    function_signature="0xae962acf",
+                    function_name="setNodeOperatorStakingLimit",
+                    inputs=[
+                        FuncInput(
+                            name="_id",
+                            type="uint256",
+                            value=12,
+                        ),
+                        FuncInput(
+                            name="_stakingLimit",
+                            type="uint64",
+                            value=29,
+                        ),
+                    ],
+                    properties=dict(),
+                    outputs=list(),
+                )
+            ]
+        )
+    ),
+)
+
+
+@pytest.fixture(scope='module', params=parse_with_decoding_examples)
+def parse_with_decoding_example(request):
+    """Get positive test case for parsing with encoding of calls."""
+    return request.param.raw_script, request.param.parsed_script
+
+
+@pytest.fixture(scope='module')
+def abi_storage(api_key: str, target_net: str):
+    """Return prepared abi storage."""
+    return get_cached_etherscan_api(api_key=api_key, net=target_net)
+
+
+def test_parse_with_call_decoding(abi_storage, parse_with_decoding_example):
+    """Run tests for positive parsing examples with encoding of calls."""
+    script_code, prepared = parse_with_decoding_example
+    parsed = parse_script(script_code, abi_storage)
+
+    assert parsed.spec_id == prepared.spec_id
+    assert len(prepared.calls) == len(parsed.calls)
+
+    for prepared_call, parsed_call in zip(
+            prepared.calls, parsed.calls
+    ):
+        assert parsed_call.contract_address == prepared_call.contract_address
+        assert parsed_call.function_signature == \
+            prepared_call.function_signature
+        assert parsed_call.function_name == prepared_call.function_name
+
+        for prepared_call.input, parsed_call.input in zip(
+            prepared_call.inputs, parsed_call.inputs
+        ):
+            assert parsed_call.input.name == prepared_call.input.name
+            assert parsed_call.input.type == prepared_call.input.type
+            assert parsed_call.input.value == prepared_call.input.value


### PR DESCRIPTION
Issue - #4 

- [x] Added optional functionality of [decode_function_call](https://github.com/lidofinance/AVotesParser/blob/master/production/avotes-parser-core/avotes_parser/core/decoding.py) to [parse_script](https://github.com/lidofinance/AVotesParser/blob/master/production/avotes-parser-core/avotes_parser/core/parsing.py)
    - [x] Test
    - [x] Linting