### PR TITLE
Fix: update tox envs

### DIFF
--- a/production/avotes-parser-cli/tox.ini
+++ b/production/avotes-parser-cli/tox.ini
@@ -13,7 +13,7 @@ skip_install = True
 allowlist_externals = poetry
 commands =
     poetry install -v
-basepython = python3.9
+basepython = python3.10
 
 [testenv:lint]
 allowlist_externals = flake8

--- a/production/avotes-parser-core/tests/conftest.py
+++ b/production/avotes-parser-core/tests/conftest.py
@@ -14,7 +14,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--infura-id', type=str,
         default=None, help='Infura project ID '
-                           'for interaction with goerli.'
+                           'for interaction with network.'
     )
 
 

--- a/production/avotes-parser-core/tox.ini
+++ b/production/avotes-parser-core/tox.ini
@@ -12,7 +12,7 @@ ignore = D200,D400
 [testenv]
 skip_install = True
 allowlist_externals = poetry
-basepython = python3.9
+basepython = python3.10
 
 [testenv:lint]
 extras = linter
@@ -21,4 +21,5 @@ commands =
     flake8 {toxinidir}/avotes_parser/core {toxinidir}/tests
 
 [testenv:tests]
-commands = poetry run pytest {posargs}
+allowlist_externals = pytest
+commands = pytest {posargs}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -27,7 +27,9 @@ test_target() {
   echo "--- RUN TESTS: ${TARGET} ---"
   cd "production/${TARGET}"
   poetry install -v
-  poetry run tox -c "." -- --apikey="$API_KEY" --infura-id="$INFURA_ID"
+  poetry shell
+  tox -c "." -- --apikey="$API_KEY" --infura-id="$INFURA_ID"
+  exit
   rm -rf $HOME/.cache/pypoetry/artifacts/*
   cd -
 }

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -27,9 +27,7 @@ test_target() {
   echo "--- RUN TESTS: ${TARGET} ---"
   cd "production/${TARGET}"
   poetry install -v
-  poetry shell
-  tox -c "." -- --apikey="$API_KEY" --infura-id="$INFURA_ID"
-  exit
+  poetry run -- tox -c "." -- --apikey="$API_KEY" --infura-id="$INFURA_ID"
   rm -rf $HOME/.cache/pypoetry/artifacts/*
   cd -
 }


### PR DESCRIPTION
tl;dr: This PR resolves the red cross CI problem ❌.

There are some version bumps for poetry, tox. 
Use the updated syntax for the test invocation (extra `--` for `poetry run`)